### PR TITLE
Dropping support for Python version < 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
 install:
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@
   Features:
 
 - Organizational login (cookies.txt)    - Regular login (Username + Password combination)
-- Cross platform support                - Runs on both Python2 and Python3
+- Cross platform support                - Bulk downloads
 - Exercise file download                - Subtitles download
 - Lib. card + pin support for ex-file   - Schedule download (Download later)
 - Creates Course & Chapter folders      - Generate Info files
 - Videos and subtitles renaming         - Move videos/subtitles to correct Chapters
-- Adjust preferences (settings.json)    - aria2 external downloader (for faster downloads)
-- Bulk downloads                        
+- Adjust preferences (settings.json)    - aria2 external downloader (for faster downloads)                        
 ```
 
 ![**Lyndor in Action**](./images/lyndor-run.gif)
@@ -38,8 +37,8 @@ def Operating_Systems():
 
 ## Requirements
 
-* **Python 2 or Python 3**
-* Python is free and comes pre-installed in MacOS and most Linux distributions, Windows users can install python from official [**python**](https://www.python.org/download/releases/2.7/) website
+* **Python 3.6 or above**
+* Python is free to download [**python**](https://www.python.org/downloads/release/python-370/)
 * **NOTE:** Windows users must add python.exe to path
 
 ![**Windows installer**](https://www.howtogeek.com/wp-content/uploads/2017/05/ximg_591a09e55df0e.png.pagespeed.gp+jp+jw+pj+ws+js+rj+rp+rw+ri+cp+md.ic.Sy31NTwaIO.png)

--- a/install.py
+++ b/install.py
@@ -10,14 +10,17 @@ LYNDOR_PATH = real_path[:real_path.find('install.py')]
 
 def check_os():
     '''Check operating system'''
-    if sys.platform.lower() == 'darwin':
+    
+    platform = sys.platform.lower()
+
+    if platform == 'darwin':
         return 'macos'
-    elif sys.platform.lower() == 'win32':
+    elif platform == 'win32':
         return 'windows'
-    elif sys.platform.lower() == 'linux2' or sys.platform.lower() == 'linux':
+    elif platform == 'linux2' or platform == 'linux':
         return 'linux'
     else:
-        print('operating system not supported:', sys.platform.lower())
+        print('operating system not supported:', platform)
         sys.exit('unknown operating system.')
 
 

--- a/install.py
+++ b/install.py
@@ -17,7 +17,7 @@ def check_os():
     elif sys.platform.lower() == 'linux2' or sys.platform.lower() == 'linux':
         return 'linux'
     else:
-        print('operating system not supported: ' + sys.platform.lower())
+        print('operating system not supported:', sys.platform.lower())
         sys.exit('unknown operating system.')
 
 

--- a/module/cookies.py
+++ b/module/cookies.py
@@ -13,29 +13,19 @@ except ImportError:
 
 def add_new_line(cookie, line):
     '''returns cookie file with NETSCAPE line'''
-    # fix for python 2.x and 3.x
-    try:
-        with file(cookie, 'r') as original: data = original.read()
-        with file(cookie, 'w') as modified: modified.write(line + data)
-    except NameError:
-        with open(cookie, 'r') as original: data = original.read()
-        with open(cookie, 'w') as modified: modified.write(line + data)
+    
+    with open(cookie, 'r') as original: data = original.read()
+    with open(cookie, 'w') as modified: modified.write(line + data)
     
     return modified
 
 def edit_hex_file(cookie):
     '''returns cookie file without carriage return'''
     # fix for python 2.x and 3.x
-    try:
-        with file(cookie, 'r') as f:
-            newcontent = f.read().replace("\r\n", "\n")
-        with file(cookie, 'w') as f:
-            newfile = f.write(newcontent)
-    except NameError:
-        with open(cookie, 'r') as f:
-            newcontent = f.read().replace("\r\n", "\n")
-        with open(cookie, 'w') as f:
-            newfile = f.write(newcontent)       
+    with open(cookie, 'r') as f:
+        newcontent = f.read().replace("\r\n", "\n")
+    with open(cookie, 'w') as f:
+        newfile = f.write(newcontent)       
     return newfile
 
 def edit_cookie(cookie, line):

--- a/module/exercise_file.py
+++ b/module/exercise_file.py
@@ -79,7 +79,7 @@ def use_selenium(url, course_folder, driver):
 
     try:
         for exercise in exercises:
-                print('Downloading: ' +  exercise.text)
+                print(f"Downloading: {exercise.text}")
                 exercise.click()
     except Exception as e:
         sys.exit(e)
@@ -105,7 +105,7 @@ def use_selenium(url, course_folder, driver):
                     if os.path.getsize(folder) > 0:     # if file downloaded completely.
                         try:
                             shutil.move(exercise.text, course_folder)
-                            print('\nMoved to course folder: ' + exercise.text)
+                            print(f'\nMoved to course folder: {exercise.text}')
                         except:
                             print('\nMoving error: File already exists.')
                         
@@ -139,12 +139,13 @@ def use_aria2(url, course_folder, cookie_path, driver):
 
     for exercise in exercises:
         exercise_message = message.return_colored_message(Fore.LIGHTYELLOW_EX, exercise.text)
-        print("To be Downloaded: {}".format(exercise_message))
+        print(f"To be Downloaded: {exercise_message}")
+
 
     total_ex_files = len(exercise_file_urls)
     counter = 1
     for url in exercise_file_urls:
-        print(message.return_colored_message(Fore.LIGHTYELLOW_EX, "\nDownloading {} of {}".format(counter, total_ex_files)))
+        print(message.return_colored_message(Fore.LIGHTYELLOW_EX, f"\nDownloading {counter} of {total_ex_files}"))
         counter += 1
         os.system("aria2c --load-cookie='{}' {}".format(cookie_path, url))
     

--- a/module/move.py
+++ b/module/move.py
@@ -25,13 +25,13 @@ def vid_srt_to_chapter(url, course_folder):
     video_count = 0
 
     total_videos = save.total_videos(url) 
-    print('\nVideos available: {}'.format(total_videos))
+    print(f'\nVideos available: {total_videos}' )
 
     downloaded_videos = 0
     for file in os.listdir(course_folder):
         if file.endswith('.mp4'):
             downloaded_videos += 1
-    print('Videos downloaded: {}\n'.format(downloaded_videos))
+    print(f'Videos downloaded: {downloaded_videos}\n')
 
     for li in ul_video:
         chapter_name = chapters[chapter_count].text
@@ -68,7 +68,7 @@ def vid_srt_to_chapter(url, course_folder):
         if total_videos > 99:
             digit = 3
 
-        print('🔰  Moving files inside: ' + str(chapter_name))
+        print(f'🔰  Moving files inside: {str(chapter_name)}')
         for video in group:
             video_count += 1
             
@@ -107,9 +107,9 @@ def vid_srt_to_chapter(url, course_folder):
             except:
                 moved_successfully = ""         # prevent successful message
                 try:
-                    print('🤕  File not found: ' + str(video_name))
+                    print(f"🤕  File not found: {str(video_name)}")
                 except UnicodeEncodeError:
-                    print('🤕  File not found: ' + (video_name).encode('utf-8'))
+                    print(f"🤕  File not found: {(video_name).encode('utf-8')}")
 
             try:
                 shutil.move(subtitle_name, chapter_name)

--- a/module/read.py
+++ b/module/read.py
@@ -43,7 +43,7 @@ try:
     download_subtitles      = settings_json('preferences', 'download_subtitles')
     download_exercise_file  = settings_json('preferences', 'download_exercise_file')
     web_browser_for_exfile  = settings_json('preferences', 'web_browser_for_exfile')
-    aria2_installed     = settings_json('preferences', 'aria2_installed')
+    aria2_installed         = settings_json('preferences', 'aria2_installed')
     download_time           = settings_json('preferences', 'download_time')
     redownload_course       = settings_json('preferences', 'redownload_course')
 except Exception as e:

--- a/module/rename.py
+++ b/module/rename.py
@@ -14,7 +14,7 @@ def videos(path):
             if vid[-5] == ' ':
                 new_name = vid[:-5] + '.mp4'
                 os.rename(os.path.join(path, vid), os.path.join(path, new_name))
-                print('renamed >>> ' + new_name)
+                print('renamed >>>', new_name)
 
 
 def subtitles(path):
@@ -25,4 +25,4 @@ def subtitles(path):
             if sub[-8] == ' ':
                 new_name = sub[:-8] + '.en.srt'
                 os.rename(os.path.join(path, sub), os.path.join(path, new_name))
-                print('renamed >>> ' + new_name)
+                print('renamed >>> ', new_name)

--- a/module/save.py
+++ b/module/save.py
@@ -95,7 +95,7 @@ def course(url, lynda_folder_path):
                     else:
                         sys.stdout.write(Fore.LIGHTRED_EX + "\n- oops!! that's not a valid choice, type Y or N: " + Fore.RESET)
     
-    print(u'\ncreating course folder at: {}'.format(current_course))
+    print(f'\ncreating course folder at: {current_course}')
     os.mkdir(current_course)
 
 def info_file(url, course_path):
@@ -289,10 +289,8 @@ def aria2():
         with open('./aria2c/aria2c.zip', 'wb') as f:
             f.write(aria.content)
         print('\n>>> aria2c.zip has been downloaded inside "Lyndor/aria2c" folder')
-        print('>>> unzipping aria2c.zip')
         unzip('aria2c', 'aria2c.zip')
-        print(
-            '>>> aria2c.zip has been unzipped, copy its path and save to PATH variable.\n')
+        print('>>> aria2c.zip has been unzipped, copy its path and save to PATH variable.\n')
 
 
 def unzip(directory, zip_file):
@@ -336,8 +334,7 @@ def settings_json():
     json.dump(settings_dict, out_file, indent=4)
     out_file.close()
 
-    print('\n>>> Courses will be saved at -> ' +
-          read.settings_json('preferences', 'location') + '\n')
+    print(f'\n>>> Courses will be saved at -> {read.location} \n')
     print('-> settings.json file created at Lyndor/settings/static/js/settings.json\n')
 
 
@@ -346,8 +343,7 @@ def lynda_folder():
     path = read.settings_json('preferences', 'location')
     if not os.path.exists(path):
         os.makedirs(path)
-        print('-> Lynda folder created at: ' +
-              read.settings_json('preferences', 'location') + '\n')
+        print(f'-> Lynda folder created at: {read.location} \n')
     else:
         print('>>> Lynda folder already exists\n')
 
@@ -402,7 +398,7 @@ def webdriver():
         os.mkdir('webdriver')
     except:
         pass
-    print('\n-> Downloading web driver for ' + install.check_os())
+    print('\n-> Downloading web driver for', install.check_os())
 
     if install.check_os() == 'windows':
         chrome_url = 'https://chromedriver.storage.googleapis.com/2.35/chromedriver_win32.zip'

--- a/module/save.py
+++ b/module/save.py
@@ -334,7 +334,7 @@ def settings_json():
     json.dump(settings_dict, out_file, indent=4)
     out_file.close()
 
-    # print(f'\n>>> Courses will be saved at -> {read.location} \n')
+    print(f'\n>>> Courses will be saved at -> {read.settings_json('preferences', 'location')} \n')
     print('-> settings.json file created at Lyndor/settings/static/js/settings.json\n')
 
 
@@ -343,7 +343,7 @@ def lynda_folder():
     path = read.settings_json('preferences', 'location')
     if not os.path.exists(path):
         os.makedirs(path)
-        print(f'-> Lynda folder created at: {read.location} \n')
+        print(f'-> Lynda folder created at: {path} \n')
     else:
         print('>>> Lynda folder already exists\n')
 

--- a/module/save.py
+++ b/module/save.py
@@ -334,7 +334,7 @@ def settings_json():
     json.dump(settings_dict, out_file, indent=4)
     out_file.close()
 
-    print(f'\n>>> Courses will be saved at -> {read.location} \n')
+    # print(f'\n>>> Courses will be saved at -> {read.location} \n')
     print('-> settings.json file created at Lyndor/settings/static/js/settings.json\n')
 
 

--- a/module/save.py
+++ b/module/save.py
@@ -334,7 +334,7 @@ def settings_json():
     json.dump(settings_dict, out_file, indent=4)
     out_file.close()
 
-    print(f'\n>>> Courses will be saved at -> {read.settings_json('preferences', 'location')} \n')
+    print(f"\n>>> Courses will be saved at -> {read.settings_json('preferences', 'location')} \n")
     print('-> settings.json file created at Lyndor/settings/static/js/settings.json\n')
 
 

--- a/module/save.py
+++ b/module/save.py
@@ -95,7 +95,7 @@ def course(url, lynda_folder_path):
                     else:
                         sys.stdout.write(Fore.LIGHTRED_EX + "\n- oops!! that's not a valid choice, type Y or N: " + Fore.RESET)
     
-    print('\ncreating course folder at: {}'.format(current_course))
+    print(u'\ncreating course folder at: {}'.format(current_course))
     os.mkdir(current_course)
 
 def info_file(url, course_path):
@@ -204,25 +204,27 @@ def contentmd(url):
     chapter_count = 0
     video_count = 0
 
-    with open('CONTENT.md', 'a') as content_md:
-        bug = False
-        for li in ul_video:
+
+    content_md = io.open('CONTENT.md', mode="a", encoding="utf-8")
+
+    bug = False
+    for li in ul_video:
+        try:
+            chapter_name = u'\n\n## {}\n'.format(chapters[chapter_count].text)
+            content_md.writelines(chapter_name)
+        except Exception:
+            bug = True
+            break              
+        chapter_count += 1
+        group = li.find_all('a', class_='video-name')
+        for video in group:
+            video_count += 1
             try:
-                chapter_name = '\n\n## {}\n'.format(chapters[chapter_count].text)
-                content_md.writelines(chapter_name)
+                video_name = u"\n* {} - {}".format(str(video_count).zfill(2), video.text.strip())
+                content_md.writelines(video_name)
             except Exception:
                 bug = True
-                break              
-            chapter_count += 1
-            group = li.find_all('a', class_='video-name')
-            for video in group:
-                video_count += 1
-                try:
-                    video_name = "\n* {} - {}".format(str(video_count).zfill(2), video.text.strip())
-                    content_md.writelines(video_name)
-                except Exception:
-                    bug = True
-                    break
+                break
     if bug:
         print('🤕  There seems to be an error while writing to content.md, please report the bug on GitHub')
     else:

--- a/run.py
+++ b/run.py
@@ -63,7 +63,7 @@ def schedule_download(url):
                 if time.strftime("%H:%M") == read.download_time:
                     download_course(url)
                     return
-                print('Download will start at: ' + read.download_time + ', leave this window open.')
+                print(f'Download will start at: {read.download_time} leave this window open.')
                 time.sleep(60)
         except KeyboardInterrupt:
             sys.exit(message.colored_message(Fore.LIGHTRED_EX, "\n- Program Interrupted!!\n"))


### PR DESCRIPTION
- dropping support for python version < 3.6
- Lyndor now only supports python 3.6 and above (To leverage the latest Python features) and
- reduce the time and efforts spent to support Python 2