### PR TITLE
CONTENT.md markdown links for chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Just edit your preferences and add your credentials here then simply hit Save bu
     },
     "preferences": {
         "location": "/path/to/folder/Lynda",
-        "markdown_links": false,                    // use markdown links for chapters in CONTENT.md
+        "markdown_links": true,                     // use markdown links for chapters in CONTENT.md
         "download_subtitles": true,                 // set false otherwise
         "download_exercise_file": true,             // set false otherwise
         "web_browser_for_exfile": "chrome",         // prefered web browser "chrome" or "firefox"

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Just edit your preferences and add your credentials here then simply hit Save bu
     },
     "preferences": {
         "location": "/path/to/folder/Lynda",
+        "markdown_links": false,                    // use markdown links for chapters in CONTENT.md
         "download_subtitles": true,                 // set false otherwise
         "download_exercise_file": true,             // set false otherwise
         "web_browser_for_exfile": "chrome",         // prefered web browser "chrome" or "firefox"

--- a/module/read.py
+++ b/module/read.py
@@ -40,6 +40,7 @@ try:
     # read preferences
     location                = settings_json('preferences', 'location')
     exfile_download_method  = settings_json('preferences', 'exfile_download_method')
+    markdown_links          = settings_json('preferences', 'markdown_links')
     download_subtitles      = settings_json('preferences', 'download_subtitles')
     download_exercise_file  = settings_json('preferences', 'download_exercise_file')
     web_browser_for_exfile  = settings_json('preferences', 'web_browser_for_exfile')

--- a/module/save.py
+++ b/module/save.py
@@ -226,7 +226,6 @@ def contentmd(url):
             break              
         chapter_count += 1
         group = li.find_all('a', class_='video-name')
-        # TODO: Make the video markdown option with a setting that shows up in the settings.py
         for video in group:
             video_count += 1
             try:

--- a/module/save.py
+++ b/module/save.py
@@ -155,6 +155,8 @@ def info_file(url, course_path):
     message.print_line(message.INFO_FILE_CREATED)
 
 def format_chapter(chapter, chapter_count):
+    ''' format chapter text '''
+
     # handle empty named chapters
     if len(chapter) == 0:
         chapter = "Unnamed"

--- a/module/save.py
+++ b/module/save.py
@@ -219,6 +219,24 @@ def contentmd(url):
             # handle empty named chapters
             if len(chapter) == 0:
                 chapter = "Unnamed"
+
+            # Check for valid characters
+            replacements = [
+                ('[?]', ''),
+                ('[/]', '_'),
+                ('["]', "'"),
+                ('[:><\\|*]', ' -')
+            ]
+
+            for old, new in replacements:
+                chapter_title = re.sub(old, new, chapter)                
+
+            if chapter[1] == '.':
+                chapter_title = str(chapter_count).zfill(2) + '. ' + chapter[3:]
+            elif chapter[2] == '.':
+                chapter_title = str(chapter_count).zfill(2) + '. ' + chapter[4:]
+            else:
+                chapter_title = str(chapter_count).zfill(2) + '. ' + chapter
             
             chapter_name = u'\n\n## {}\n'.format(chapter)
             content_md.writelines(chapter_name)
@@ -227,11 +245,13 @@ def contentmd(url):
             break              
         chapter_count += 1
         group = li.find_all('a', class_='video-name')
+        # TODO: Make the video markdown option with a setting that shows up in the settings.py
         for video in group:
             video_count += 1
             try:
-                video_name = u"\n* {} - {}".format(str(video_count).zfill(2), video.text.strip())
-                content_md.writelines(video_name)
+                video_name = u"{} - {}".format(str(video_count).zfill(2), video.text.strip())
+                video_markdown = "\n* [" + video_name + "](" + chapter_title + "/" + video_name + ".mp4)"
+                content_md.writelines(video_markdown)
             except Exception:
                 bug = True
                 break

--- a/module/save.py
+++ b/module/save.py
@@ -191,7 +191,7 @@ def chapters(url, course_folder_path):
 
     
     for h in heading4:
-        chapter = format_chapter(h.text, chapter_no)    
+        chapter = format_chapter(h.text, chapter_no)
         chapter_no += 1
         message.print_line(chapter)
 
@@ -231,7 +231,10 @@ def contentmd(url):
             video_count += 1
             try:
                 video_name = u"{} - {}".format(str(video_count).zfill(2), video.text.strip())
-                video_markdown = "\n* [" + video_name + "](" + chapter + "/" + video_name + ".mp4)"
+                if read.markdown_links:
+                    video_markdown = "\n* [" + video_name + "](" + chapter + "/" + video_name + ".mp4)"
+                else:
+                    video_markdown = "\n* " + video_name
                 content_md.writelines(video_markdown)
             except Exception:
                 bug = True
@@ -330,6 +333,7 @@ def settings_json():
         },
         "preferences": {
             "location": install.set_path() + '/Lynda',
+            "markdown_links": False,
             "download_subtitles": False,
             "download_exercise_file": False,                # feature unavailable for organizational login
             "web_browser_for_exfile": "chrome",             # select chrome or firefox as a web browser

--- a/settings/static/js/settings.js
+++ b/settings/static/js/settings.js
@@ -52,6 +52,14 @@ $(document).ready(function(){
         settingsJson.credentials.exfile_download_pref = "regular-login";
     })
 
+    // use markdown links for chapters preferences
+    $('#markdown-links-true').click(function(){
+        settingsJson.preferences.markdown_links = true;
+    })    
+    $('#markdown-links-false').click(function(){
+        settingsJson.preferences.markdown_links = false;
+    })
+
     // download subtitles preferences
     $('#download-subtitles-true').click(function(){
         settingsJson.preferences.download_subtitles = true;
@@ -141,6 +149,12 @@ if(settingsJson.credentials.exfile_download_pref == "regular-login")
     document.getElementById('exfile-regular-login').classList.add("active");
 else
     document.getElementById('exfile-library-login').classList.add("active");
+
+// Read markdown links for chapters state
+if(settingsJson.preferences.markdown_links == true)
+    document.getElementById('markdown-links-true').classList.add("active"); 
+else
+    document.getElementById('markdown-links-false').classList.add("active"); 
 
 // Read subtitles state
 if(settingsJson.preferences.download_subtitles == true)

--- a/settings/templates/settings.html
+++ b/settings/templates/settings.html
@@ -91,6 +91,19 @@
             <input class="form-control" type="text" id="lynda_location" />
           </div>
           <div class="form-group">
+            <label for="" class="form-text text-muted">Do you want to use markdown links for chapters?</label>
+
+            <div class="btn-group btn-group-toggle" data-toggle="buttons">
+              <label class="btn btn-secondary" id="markdown-links-true">
+                <input type="radio" autocomplete="off" checked> Yes
+              </label>
+              <label class="btn btn-secondary" id="markdown-links-false">
+                <input type="radio" autocomplete="off"> No
+              </label>
+            </div>
+            <!--Radio buttons-->
+          </div>
+          <div class="form-group">
             <label for="" class="form-text text-muted">Download subtitles</label>
 
             <div class="btn-group btn-group-toggle" data-toggle="buttons">


### PR DESCRIPTION
Thought it would be useful if you had markdown style links for the chapters so you can click through to the video directly from a markdown editor. This setting can be toggled via the `settings.json` or `http://127.0.0.1:5005`

**Example CONTENT.md**

# COURSE

## 00. COURSE CHAPTER 1

* [01 - VIDEO 1 TITLE](00. COURSE CHAPTER 1/01 - VIDEO 1.mp4)
* [02 - VIDEO 2 TITLE](00. COURSE CHAPTER 1/02 - VIDEO 2.mp4)
* [03 - VIDEO 3 TITLE](00. COURSE CHAPTER 1/03 - VIDEO 3.mp4)

P.S. Thanks for making this amazing software 🎉 